### PR TITLE
The mysql database name on dbconnect has changed

### DIFF
--- a/database error solved
+++ b/database error solved
@@ -1,0 +1,8 @@
+	$myhost = "localhost:3306";
+		$dbuser = "root";
+		$dbpass = "";
+		$dbname = "employee_record";
+		$dbname = "projectdb (1)";
+	
+		$connect = mysql_connect( $myhost, $dbuser, $dbpass ) or
+			die("Could not connect <br />" . mysql_error());


### PR DESCRIPTION
The mysql database name on dbconnect has changed 

"employee_record" to "projectdb (1)"

$myhost = "localhost:3306";
        $dbuser = "root";
        $dbpass = "";
        $dbname = "projectdb (1)";

```
    $connect = mysql_connect( $myhost, $dbuser, $dbpass ) or
        die("Could not connect <br />" . mysql_error());
```
